### PR TITLE
use smallest filtersize for initial buffer

### DIFF
--- a/src/main/scala/com/teragrep/functions/dpf_03/BloomFilterAggregator.scala
+++ b/src/main/scala/com/teragrep/functions/dpf_03/BloomFilterAggregator.scala
@@ -86,12 +86,13 @@ class BloomFilterAggregator(final val columnName: String,
   }
 
   override def merge(ours: BloomFilter, their: BloomFilter): BloomFilter = {
-    if (!ours.isCompatible(their)) {
+    val result = if (!ours.isCompatible(their)) {
       // if incompatible, return the larger filter
-      return if (ours.bitSize() < their.bitSize()) their else ours
+      if (ours.bitSize() < their.bitSize()) their else ours
+    } else {
+      ours.mergeInPlace(their)
     }
-    val merged = ours.mergeInPlace(their)
-    merged
+    result
   }
 
   /**


### PR DESCRIPTION
Replace small hard coded initial filter and use the smallest filter size from map.

- If different size filters come into merge return the larger one (case when initial filter size is updated)
- Add testing for filter size selection and missing estimate value